### PR TITLE
Fetch historical spx500 candles for monitoring

### DIFF
--- a/Bot-Trading_Swing (2).py
+++ b/Bot-Trading_Swing (2).py
@@ -406,7 +406,7 @@ ENABLE_REALTIME_MONITORING = True   # Enable real-time price monitoring for SL/T
 REALTIME_CHECK_INTERVAL = 30        # Seconds between real-time price checks
 BOT_CYCLE_MODE = "HOURLY"            # Options: "HOURLY", "CONTINUOUS", "CUSTOM"
 BOT_CYCLE_INTERVAL = 3600            # Seconds between cycles (only used if BOT_CYCLE_MODE = "CUSTOM")
-ENABLE_WICK_DETECTION = True        # Check candle wicks/shadows for SL/TP hits
+ENABLE_WICK_DETECTION = False       # Check candle wicks/shadows for SL/TP hits
 WICK_DETECTION_CANDLES = 3          # Number of recent candles to check for wicks
 MAX_REALTIME_RETRIES = 3            # Max retries for real-time price fetching
 REALTIME_TIMEOUT = 10               # Timeout in seconds for real-time API calls


### PR DESCRIPTION
Disable wick detection to prevent the real-time monitor from fetching historical candle data.

---
<a href="https://cursor.com/background-agent?bcId=bc-293d6a22-3790-4076-99f8-6409aa38ff8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-293d6a22-3790-4076-99f8-6409aa38ff8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

